### PR TITLE
fix: :ambulance: fixes CommitMultiStore() when the application loads

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -625,18 +625,19 @@ func New(
 	app.SetAnteHandler(anteHandler)
 	app.SetEndBlocker(app.EndBlocker)
 
-	if loadLatest {
-		if err := app.LoadLatestVersion(); err != nil {
-			tmos.Exit(err.Error())
-		}
-	}
-
 	if manager := app.SnapshotManager(); manager != nil {
 		err := manager.RegisterExtensions(
 			wasmkeeper.NewWasmSnapshotter(app.CommitMultiStore(), &app.wasmKeeper),
 		)
 		if err != nil {
 			panic(fmt.Errorf("failed to register snapshot extension: %s", err))
+		}
+
+	}
+
+	if loadLatest {
+		if err := app.LoadLatestVersion(); err != nil {
+			tmos.Exit(err.Error())
 		}
 		ctx := app.BaseApp.NewUncachedContext(true, tmproto.Header{})
 

--- a/config.yml
+++ b/config.yml
@@ -7,8 +7,6 @@ validator:
   name: alice
   staked: "100000000stake"
 client:
-  openapi:
-    path: "docs/static/openapi.yml"
   vuex:
     path: "vue/src/store"
 faucet:


### PR DESCRIPTION
The application should load after the manager registers the extension, if not the loading crashes because the app is sealed. 